### PR TITLE
Use `tinyrecord` to provide transactional thread-safety

### DIFF
--- a/TIM/threat_intelligence.py
+++ b/TIM/threat_intelligence.py
@@ -6,6 +6,7 @@ import splunklib.client as client
 from collections import defaultdict
 from datetime import datetime, timedelta
 from operator import itemgetter
+from tinyrecord import transaction
 
 
 def gen_brute_force_query(config):
@@ -228,7 +229,8 @@ def detect_threats(app, threat_query, geo_locations_intel, config):
                         "location": get_point_location(location,
                             geo_locations_intel,)
                     }
-                    db.brute_force_table.insert(brute_force_threats)
+                    with transaction(db.brute_force_table) as inserter:
+                        inserter.insert(brute_force_threats)
 
             elif result['threat'] == "multi_logins":
                 for (_, time, mac, unique_logins, username) in zip(
@@ -259,7 +261,8 @@ def detect_threats(app, threat_query, geo_locations_intel, config):
                         "location": get_point_location(location,
                             geo_locations_intel,)
                     }
-                    db.multi_logins_table.insert(multi_logins_threats)
+                    with transaction(db.multi_logins_table) as inserter:
+                        inserter.insert(multi_logins_threats)
 
     db.db.close()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,6 @@ Flask-Cors==3.0.8
 APScheduler==3.6.3
 splunk-sdk==1.6.12 
 tinydb==3.15.2
+tinyrecord==0.1.5
 pyYAML==5.3.1
 PyJWT==1.7.1


### PR DESCRIPTION
The `tinydb` database would occasionally become corrupted, resulting in
errors every time SPA would attempt to access TIM. To fix this,
`tinyrecord` can be used to make changes atomic instead of potentially
cancellable.